### PR TITLE
Support nullable maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Since the original repo seems to be abandoned, this fork addresses the following
 
 - [x] NPE when deserializing nullable record attributes of type array
 - [x] deserializing map keys as keywords
+- [x] serializing nullable maps
 - [ ] logical types (aka support for timestamps, dates etc)
 
 ## Installation
@@ -23,7 +24,7 @@ Abracad is available on Clojars.  Add this `:dependency` to your
 Leiningen `project.clj`:
 
 ```clj
-[nomnom/abracad "0.4.15"]
+[nomnom/abracad "0.4.16-SNAPSHOT"]
 ```
 
 ## Usage

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nomnom/abracad "0.4.15"
+(defproject nomnom/abracad "0.4.16-SNAPSHOT"
   :description "De/serialize Clojure data structures with Avro"
   :url "http://github.com/nomnom/abracad"
   :licenses [{:name "Eclipse Public License"

--- a/src/clojure/abracad/avro/write.clj
+++ b/src/clojure/abracad/avro/write.clj
@@ -240,6 +240,7 @@ record serialization."
     Schema$Type/INT     (integer? datum)
     Schema$Type/DOUBLE  (float? datum)
     Schema$Type/FLOAT   (float? datum)
+    Schema$Type/MAP     (map? datum)
     #_ else             false))
 
 (defn resolve-union*

--- a/test/abracad/avro_test.clj
+++ b/test/abracad/avro_test.clj
@@ -303,8 +303,8 @@
                     :fields [{:name "name"
                               :type ["null" "string"]}
                              {:name "attributes"
-                              :type {:type  "map"
-                                     :values ["string" "long"]}}]}
+                              :type ["null"  {:type  "map"
+                                              :values ["string" "long"]}]}]}
         schema (avro/parse-schema schema-def)
         input {:name "test"
                :attributes {:key-1 "a"


### PR DESCRIPTION
Looks like Abracad (or Avro?) doesn't support nullable maps.

# What's happening?

Given the following schema:

```json

{  "type" : "record", "name" : "Test", 
  "fields" : [
   { "name" : "id", "type" : "string" },
    { "name" : "metadata", "types" : ["null",  {"type" : "map", "values" : "string" } ] }
  ]

}
```

These records even though valid, but because of the bug, cannot be serialized:

```clojure
{ :name "test 1"  :metadata {} }
{ :name "test 2" }
```

as they fail with the following error:

```
not in union ["null",  {"type" : "map", "values" : "string" }] {}
```
